### PR TITLE
fsGroup is applicable to PodSecurityContext not container

### DIFF
--- a/config/deployment.yml
+++ b/config/deployment.yml
@@ -33,7 +33,8 @@ spec:
         securityContext:
           runAsUser: 1000
           runAsGroup: 2000
-          fsGroup: 3000
+      securityContext:
+        fsGroup: 3000
       volumes:
       - name: template-fs
         emptyDir:


### PR DESCRIPTION
Fixes validation error `error validating data: ValidationError(Deployment.spec.template.spec.containers[0].securityContext): unknown field "fsGroup" in io.k8s.api.core.v1.SecurityContext;`

See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podsecuritycontext-v1-core and https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core