### PR TITLE
Add support for ytt templating with multiple paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /controller
 /tmp
+.idea

--- a/docs/app-spec.md
+++ b/docs/app-spec.md
@@ -114,6 +114,10 @@ spec:
                 name: cfgmap-name
                 # specifies where to place files found in config map (optional)
                 directoryPath: dir
+        # if ytt needs to use multiple paths, explicitly list all paths (optional) 
+        - paths:
+          - dir/common
+          - dir/nested/app
 
     # use kbld to resolve image references to use digests
     - kbld: {}

--- a/pkg/apis/kappctrl/v1alpha1/types_template.go
+++ b/pkg/apis/kappctrl/v1alpha1/types_template.go
@@ -16,6 +16,7 @@ type AppTemplateYtt struct {
 	IgnoreUnknownComments bool            `json:"ignoreUnknownComments,omitempty"`
 	Strict                bool            `json:"strict,omitempty"`
 	Inline                *AppFetchInline `json:"inline,omitempty"`
+	Paths                 []string        `json:"paths,omitempty"`
 }
 
 type AppTemplateKbld struct{}

--- a/pkg/apis/kappctrl/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kappctrl/v1alpha1/zz_generated.deepcopy.go
@@ -731,6 +731,11 @@ func (in *AppTemplateYtt) DeepCopyInto(out *AppTemplateYtt) {
 		*out = new(AppFetchInline)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Paths != nil {
+		in, out := &in.Paths, &out.Paths
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/fetch/http.go
+++ b/pkg/fetch/http.go
@@ -140,12 +140,12 @@ func (t *HTTP) tryZip(path, dstPath string) (bool, error) {
 
 		srcZipFile, err := f.Open()
 		if err != nil {
-			return true, fmt.Errorf("Opening zip file: %s", err)
+			return false, fmt.Errorf("Opening zip file: %s", err)
 		}
 
 		err = t.writeIntoFileAndClose(srcZipFile, dstPath, f.Name)
 		if err != nil {
-			return true, err
+			return false, err
 		}
 	}
 

--- a/pkg/template/ytt.go
+++ b/pkg/template/ytt.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	goexec "os/exec"
+	"path"
 
 	"github.com/k14s/kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"github.com/k14s/kapp-controller/pkg/exec"
@@ -33,7 +34,14 @@ func (t *Ytt) TemplateStream(input io.Reader) exec.CmdRunResult {
 }
 
 func (t *Ytt) template(dirPath string, input io.Reader) exec.CmdRunResult {
-	args := t.addArgs([]string{"-f", dirPath})
+	var args []string
+	if len(t.opts.Paths) == 0 {
+		args = t.addArgs([]string{"-f", dirPath})
+	} else {
+		for _, p := range t.opts.Paths {
+			args = append(args, t.addArgs([]string{"-f", path.Join(dirPath, p)})...)
+		}
+	}
 
 	args, inlineDir, err := t.addInlinePaths(args)
 	if inlineDir != nil {


### PR DESCRIPTION
- Added `paths` in App spec which can be used to specify multiple paths.
- [Bug fix]: http fetch fails for tar.gz as `tryZip` returns `true` for errors

Signed-off-by: Vijay Katam <vkatam@vmware.com>