### PR TITLE
Add subfolders for fetch directives

### DIFF
--- a/pkg/app/app_fetch.go
+++ b/pkg/app/app_fetch.go
@@ -18,17 +18,25 @@ func (a *App) fetch(dstPath string) exec.CmdRunResult {
 
 	var result exec.CmdRunResult
 
-	for i, fetch := range a.app.Spec.Fetch {
-		subPath := path.Join(dstPath, strconv.Itoa(i))
-		err := os.Mkdir(subPath, os.FileMode(0700))
+	if len(a.app.Spec.Fetch) == 1 {
+		fetch := a.app.Spec.Fetch[0]
+		err := a.fetchOne(fetch, dstPath)
 		if err != nil {
-			result.AttachErrorf(fmt.Sprintf("Fetching (%d): ", i)+"%s", err)
-			break
+			result.AttachErrorf("Fetching (0): %s", err)
 		}
-		err = a.fetchOne(fetch, subPath)
-		if err != nil {
-			result.AttachErrorf(fmt.Sprintf("Fetching (%d): ", i)+"%s", err)
-			break
+	} else {
+		for i, fetch := range a.app.Spec.Fetch {
+			subPath := path.Join(dstPath, strconv.Itoa(i))
+			err := os.Mkdir(subPath, os.FileMode(0700))
+			if err != nil {
+				result.AttachErrorf(fmt.Sprintf("Fetching (%d): ", i)+"%s", err)
+				break
+			}
+			err = a.fetchOne(fetch, subPath)
+			if err != nil {
+				result.AttachErrorf(fmt.Sprintf("Fetching (%d): ", i)+"%s", err)
+				break
+			}
 		}
 	}
 

--- a/pkg/app/app_fetch.go
+++ b/pkg/app/app_fetch.go
@@ -2,6 +2,9 @@ package app
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"strconv"
 
 	"github.com/k14s/kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"github.com/k14s/kapp-controller/pkg/exec"
@@ -16,7 +19,13 @@ func (a *App) fetch(dstPath string) exec.CmdRunResult {
 	var result exec.CmdRunResult
 
 	for i, fetch := range a.app.Spec.Fetch {
-		err := a.fetchOne(fetch, dstPath)
+		subPath := path.Join(dstPath, strconv.Itoa(i))
+		err := os.Mkdir(subPath, os.FileMode(0700))
+		if err != nil {
+			result.AttachErrorf(fmt.Sprintf("Fetching (%d): ", i)+"%s", err)
+			break
+		}
+		err = a.fetchOne(fetch, subPath)
 		if err != nil {
 			result.AttachErrorf(fmt.Sprintf("Fetching (%d): ", i)+"%s", err)
 			break

--- a/test/e2e/multi_fetch_test.go
+++ b/test/e2e/multi_fetch_test.go
@@ -1,0 +1,85 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestMultiFetch(t *testing.T) {
+	env := BuildEnv(t)
+	logger := Logger{}
+	kapp := Kapp{t, env.Namespace, logger}
+
+	yaml1 := `
+apiVersion: kappctrl.k14s.io/v1alpha1
+kind: App
+metadata:
+  name: test-multi-fetch
+spec:
+  fetch:
+  - inline:
+      paths:
+        file.yml: |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: configmap
+          data:
+            key: value
+  - inline:
+      paths:
+        file.yml: |
+          #@ load("@ytt:overlay", "overlay")
+          #@overlay/match by=overlay.subset({"metadata":{"name":"configmap"}})
+          ---
+          data:
+            #@overlay/match missing_ok=True
+            overlay-key: overlay-value
+  template:
+  - ytt: {}
+  deploy:
+  - kapp:
+      delete:
+        rawOptions: ["--apply-ignored=true"]
+`
+
+	name := "test-multi-fetch"
+	cleanUp := func() {
+		kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
+	}
+
+	cleanUp()
+	defer cleanUp()
+
+	logger.Section("deploy", func() {
+		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+	})
+
+	logger.Section("verify", func() {
+		out := kapp.Run([]string{"inspect", "-a", name + "-ctrl", "--raw", "--tty=false", "--filter-kind", "ConfigMap"})
+
+		var cm corev1.ConfigMap
+
+		err := yaml.Unmarshal([]byte(out), &cm)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal: %s", err)
+		}
+
+		if cm.ObjectMeta.Name != "configmap" {
+			t.Fatalf(`Expected name to be "configmap" got %#v`, cm.ObjectMeta.Name)
+		}
+
+		if cm.Data["key"] != "value" {
+			t.Fatalf(`Expected data.key to be "value" got %#v`, cm.Data["key"])
+		}
+
+		if cm.Data["overlay-key"] != "overlay-value" {
+			t.Fatalf(`Expected data.overlay-key to be "overlay-value" got %#v`, cm.Data["key"])
+		}
+
+	})
+}


### PR DESCRIPTION
Solves #14.
This is a quick solution to allowing multiple fetch directives by creating a separate subfolder for each directive.
I.e. directive 0 is copied to `dstPath/0`, directive 1 to `dstPath/1`, etc.